### PR TITLE
Fix for using Pyinstaller with Doxc2pdf

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import subprocess
+import pythoncom
 from pathlib import Path
 from tqdm.auto import tqdm
 
@@ -15,7 +16,7 @@ __version__ = version(__package__)
 
 def windows(paths, keep_active):
     import win32com.client
-
+    pythoncom.CoInitialize()
     word = win32com.client.Dispatch("Word.Application")
     wdFormatPDF = 17
 


### PR DESCRIPTION
When creating an executable using Pyinstaller, docx2pdf will fail to load due to an error with CoInitialize.