### PR TITLE
Close progress bar after operations are done.

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -20,7 +20,8 @@ def windows(paths, keep_active):
     wdFormatPDF = 17
 
     if paths["batch"]:
-        for docx_filepath in tqdm(sorted(Path(paths["input"]).glob("*.docx"))):
+        pbar = tqdm(sorted(Path(paths["input"]).glob("*.docx")))
+        for docx_filepath in pbar:
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
             doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
@@ -33,6 +34,8 @@ def windows(paths, keep_active):
         doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
         doc.Close()
         pbar.update(1)
+
+    pbar.close()
 
     if not keep_active:
         word.Quit()


### PR DESCRIPTION
Fix progress bar is jumbling with print() log, by closing them after conversion is done. (Especially on single conversion. I added to both single and batch conversion for consistency.)