### PR TITLE
Fix progress bar

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 from pathlib import Path
 from tqdm.auto import tqdm
+from ntpath import basename
 
 try:
     # 3.8+
@@ -26,13 +27,14 @@ def windows(paths, keep_active):
             doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
             doc.Close()
     else:
-        pbar = tqdm(total=1)
         docx_filepath = Path(paths["input"]).resolve()
         pdf_filepath = Path(paths["output"]).resolve()
+        pbar = tqdm(desc=str(basename(pdf_filepath)), total=1)
         doc = word.Documents.Open(str(docx_filepath))
         doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
         doc.Close()
         pbar.update(1)
+        pbar.close()
 
     if not keep_active:
         word.Quit()


### PR DESCRIPTION
**resolve_paths(input_path, output_path)** has an else statement which does not close the tqdm progress bar pbar.

The proposed fix is to: 

* close it once the pbar.update() method is called. 
* In addition, for ease of output, pbad has a description which takes the last portion of the path so it displays the progress conversion of the pdf file.