### PR TITLE
Change close method to discard changes

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -24,14 +24,14 @@ def windows(paths, keep_active):
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
             doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-            doc.Close()
+            doc.Close(0)
     else:
         pbar = tqdm(total=1)
         docx_filepath = Path(paths["input"]).resolve()
         pdf_filepath = Path(paths["output"]).resolve()
         doc = word.Documents.Open(str(docx_filepath))
         doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-        doc.Close()
+        doc.Close(0)
         pbar.update(1)
 
     if not keep_active:


### PR DESCRIPTION
In our company's design flow, they generate docx files marked as 'ReadOnly' by some internal Word mechanism.    If you open the file manually, Word prompts if you want to open it read only or not.    The method of opening by docx2pdf apparently makes Word think you've opened it as write and wants to save changes. 

Something recently changed in Word (I guess) that changes the error to docx2pdf such that it crashes it if you cancel the save window that pops up.   This causes the script to bomb and not iterate over the batch items.

Changing doc.Close() to doc.Close(0) tell word to discard changes.   I would use the proper enum for the option (wdDoNotSaveChanges) but I couldn't be arsed to figure out where in python-land that might be defined.