### PR TITLE
 output.pdf should be mentioned instead of output.docx in cli usage e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Batch convert docx folder in-place. Output PDFs will go in the same folder:
     docx2pdf myfolder/
 
 Convert single docx file with explicit output filepath:
-    docx2pdf input.docx output.docx
+    docx2pdf input.docx output.pdf
 
 Convert single docx file and output to a different explicit folder:
     docx2pdf input.docx output_dir/


### PR DESCRIPTION
https://github.com/AlJohri/docx2pdf/blob/4b77f6c34dd77184458cf7e854910073529ff39e/README.md?plain=1#L43

In this line, the command should be docx2pdf input.docx output.pdf, it was mentioned output.docx.

I think it is a mistake