### PR TITLE
Throw an exception on JXA failure on MacOS

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -39,15 +39,6 @@ def windows(paths, keep_active):
 
 
 def macos(paths, keep_active):
-    # Verify that Microsoft Word can be launched
-    proc = subprocess.Popen(
-        ['open', '-Ra', 'Microsoft Word'], stderr=subprocess.PIPE
-    )
-    proc.wait()
-    can_launch_msword = (proc.returncode == 0)
-    if not can_launch_msword:
-        raise EnvironmentError('Microsoft Word is not available.')
-
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",
@@ -66,6 +57,8 @@ def macos(paths, keep_active):
     process.wait()
     if process.returncode != 0:
         msg = process.stderr.read().decode().rstrip()
+        if "Application can't be found" in msg:
+            raise EnvironmentError("Microsoft Word is not available.")
         raise RuntimeError(msg)
 
     def stderr_results(process):

--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -39,6 +39,15 @@ def windows(paths, keep_active):
 
 
 def macos(paths, keep_active):
+    # Verify that Microsoft Word can be launched
+    proc = subprocess.Popen(
+        ['open', '-Ra', 'Microsoft Word'], stderr=subprocess.PIPE
+    )
+    proc.wait()
+    can_launch_msword = (proc.returncode == 0)
+    if not can_launch_msword:
+        raise EnvironmentError('Microsoft Word is not available.')
+
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",

--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -39,6 +39,16 @@ def windows(paths, keep_active):
 
 
 def macos(paths, keep_active):
+    """Run the conversion on a MacOS system. Calls a JXA script, which
+    runs Microsoft Word to do the actual conversion.
+
+    See docstring for convert() for a description of the parameters.
+
+    :raises EnvironmentError: if the JXA exits with nonzero return code
+                              because Microsoft Word is not available
+    :raises RuntimeError: if the JXA exits with nonzero return code for
+                          any other reason
+    """
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",
@@ -107,6 +117,18 @@ def resolve_paths(input_path, output_path):
 
 
 def convert(input_path, output_path=None, keep_active=False):
+    """Wrapper around the conversion functions depending on whether the
+    system is Windows or MacOS. The supplied paths are 'resolved' into
+    a dictionary of path information before being given to macos() or
+    windows().
+
+    :param input_path: The path to the docx.
+    :param output_path: The path to the pdf (by default, the same name
+                        and directory as the docx, but with .pdf file
+                        extension).
+    :param keep_active: Whether to keep Microsoft Word running after the
+                        conversion(s) are complete.
+    """
     paths = resolve_paths(input_path, output_path)
     if sys.platform == "darwin":
         return macos(paths, keep_active)

--- a/tests/test_docx2pdf.py
+++ b/tests/test_docx2pdf.py
@@ -1,5 +1,35 @@
-from docx2pdf import __version__
+import subprocess
+import sys
+import unittest
+from os.path import join
+from tempfile import TemporaryDirectory
+
+from docx2pdf import __version__, convert
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == '0.1.8'
+
+
+@unittest.skipIf(sys.platform != 'darwin', 'MacOS-only tests')
+class TestMacOSFailureModes(unittest.TestCase):
+    """MacOS failure modes."""
+
+    def test_handle_microsoft_word_not_found_on_macos(self):
+        # Given that 'Microsoft Word' cannot be launched...
+        proc = subprocess.Popen(
+            ['open', '-Ra', 'Microsoft Word'], stderr=subprocess.PIPE
+        )
+        proc.wait()
+        can_launch_msword = (proc.returncode == 0)
+        if can_launch_msword:
+            self.skipTest('Microsoft Word is present, so can\'t run '
+                          'this test on this system.')
+
+        # ...when convert() is called, then a RuntimeError is raised.
+        with TemporaryDirectory() as td:
+            input_path = join(td, 'some_file.docx')
+            with self.assertRaisesRegex(
+                RuntimeError, 'Application can\'t be found.'
+            ):
+                convert(input_path)

--- a/tests/test_docx2pdf.py
+++ b/tests/test_docx2pdf.py
@@ -46,6 +46,6 @@ class TestMacOSFailureModes(unittest.TestCase):
         with TemporaryDirectory() as td:
             input_path = join(td, 'some_file.docx')
             with self.assertRaisesRegex(
-                RuntimeError, 'Application can\'t be found.'
+                EnvironmentError, 'Microsoft Word is not available.'
             ):
                 convert(input_path)

--- a/tests/test_docx2pdf.py
+++ b/tests/test_docx2pdf.py
@@ -3,12 +3,28 @@ import sys
 import unittest
 from os.path import join
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from docx2pdf import __version__, convert
 
 
 def test_version():
     assert __version__ == '0.1.8'
+
+
+class TestFailureModes(unittest.TestCase):
+    def test_input_not_docx_raises_assertion_error(self):
+        input_path = "file.not_docx"
+        with self.assertRaises(AssertionError):
+            convert(input_path)
+
+    @patch('docx2pdf.windows')
+    @patch('docx2pdf.macos')
+    def test_output_not_pdf_raises_assertion_error(self, m_macos, m_windows):
+        input_path = "file.docx"
+        output_path = "file.not_pdf"
+        with self.assertRaises(AssertionError):
+            convert(input_path, output_path)
 
 
 @unittest.skipIf(sys.platform != 'darwin', 'MacOS-only tests')


### PR DESCRIPTION
Covers #56 by raising a RuntimeError (instead of failing silently) when calling the JXA (on MacOS) gives a nonzero return code, rather than failing silently. Also increased test coverage of when the input or output paths do not have the expected file extensions.