### PR TITLE
Release Windows docx file lock after premature script exit

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -23,15 +23,23 @@ def windows(paths, keep_active):
         for docx_filepath in tqdm(sorted(Path(paths["input"]).glob("[!~]*.doc*"))):
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
-            doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-            doc.Close(0)
+            try:
+                doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
+            except:
+                raise
+            finally:
+                doc.Close(0)
     else:
         pbar = tqdm(total=1)
         docx_filepath = Path(paths["input"]).resolve()
         pdf_filepath = Path(paths["output"]).resolve()
         doc = word.Documents.Open(str(docx_filepath))
-        doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-        doc.Close(0)
+        try:
+            doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
+        except:
+            raise
+        finally:
+            doc.Close(0)
         pbar.update(1)
 
     if not keep_active:


### PR DESCRIPTION
This fixes an issue where if an exception occurs while saving the docx as a pdf (ex. if the pdf file already exists and is being used by another application), then the script will exit without closing the docx. This makes the docx uneditable until the Word process is terminated.

This issue could also be present in the macOS code, although I can't confirm it because I don't have a Mac.