### PR TITLE
Add show_progress flag and CLI option to control progress bar display

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -173,6 +173,9 @@ def cli():
     parser.add_argument(
         "--version", action="store_true", default=False, help="display version and exit"
     )
+    parser.add_argument(
+    "--no-progress", action="store_true", default=False, help="disable progress bar during conversion",
+    )
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -180,4 +183,4 @@ def cli():
     else:
         args = parser.parse_args()
 
-    convert(args.input, args.output, args.keep_active)
+    convert(args.input, args.output, args.keep_active, show_progress=not args.no_progress)

--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 __version__ = version(__package__)
 
 
-def windows(paths, keep_active, show_progress=True):
+def windows(paths, keep_active, show_progress):
     import win32com.client
 
     word = win32com.client.Dispatch("Word.Application")
@@ -51,7 +51,7 @@ def windows(paths, keep_active, show_progress=True):
         word.Quit()
 
 
-def macos(paths, keep_active, show_progress=True):
+def macos(paths, keep_active, show_progress):
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",
@@ -111,12 +111,12 @@ def resolve_paths(input_path, output_path):
     return output
 
 
-def convert(input_path, output_path=None, keep_active=False):
+def convert(input_path, output_path=None, keep_active=False, show_progress = True):
     paths = resolve_paths(input_path, output_path)
     if sys.platform == "darwin":
-        return macos(paths, keep_active)
+        return macos(paths, keep_active, show_progress)
     elif sys.platform == "win32":
-        return windows(paths, keep_active)
+        return windows(paths, keep_active, show_progress)
     else:
         raise NotImplementedError(
             "docx2pdf is not implemented for linux as it requires Microsoft Word to be installed"


### PR DESCRIPTION
This pull request introduces a show_progress parameter to the windows() and macos() functions to enable or disable the progress bar during document conversion.
Additionally, it updates the CLI to support a new --no-progress flag that allows users to disable the progress bar from the command line. This flag maps inversely to the show_progress parameter.

Changes:
Added show_progress argument to windows() and macos() functions to conditionally show the tqdm progress bar.
Added --no-progress flag to CLI to disable progress bar.
Updated CLI to pass show_progress=not args.no_progress to convert().

Motivation:
Allow users to disable progress bar for non-interactive or logging scenarios.
Improve usability and code clarity.
The default behavior remains unchanged with progress bars enabled unless --no-progress is specified