### PR TITLE
Add option to hide markup during DOCX to PDF conversion

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 __version__ = version(__package__)
 
 
-def windows(paths, keep_active, delete_comments):
+def windows(paths, keep_active, hide_markup):
     import win32com.client
 
     word = win32com.client.Dispatch("Word.Application")
@@ -24,7 +24,7 @@ def windows(paths, keep_active, delete_comments):
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
             try:
-                if delete_comments:
+                if hide_markup:
                     # Hide comments and revisions in PDF without modifying DOCX
                     doc.ActiveWindow.View.ShowComments = False
                     doc.ActiveWindow.View.ShowRevisionsAndComments = False
@@ -40,7 +40,7 @@ def windows(paths, keep_active, delete_comments):
         pdf_filepath = Path(paths["output"]).resolve()
         doc = word.Documents.Open(str(docx_filepath))
         try:
-            if delete_comments:
+            if hide_markup:
                 # Hide comments and revisions in PDF without modifying DOCX
                 doc.ActiveWindow.View.ShowComments = False
                 doc.ActiveWindow.View.ShowRevisionsAndComments = False
@@ -56,7 +56,7 @@ def windows(paths, keep_active, delete_comments):
         word.Quit()
 
 
-def macos(paths, keep_active, delete_comments):
+def macos(paths, keep_active, hide_markup):
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",
@@ -66,7 +66,7 @@ def macos(paths, keep_active, delete_comments):
         str(paths["input"]),
         str(paths["output"]),
         str(keep_active).lower(),
-        str(delete_comments).lower(),
+        str(hide_markup).lower(),
     ]
 
     def run(cmd):
@@ -117,12 +117,12 @@ def resolve_paths(input_path, output_path):
     return output
 
 
-def convert(input_path, output_path=None, keep_active=False, delete_comments=False):
+def convert(input_path, output_path=None, keep_active=False, hide_markup=False):
     paths = resolve_paths(input_path, output_path)
     if sys.platform == "darwin":
-        return macos(paths, keep_active, delete_comments)
+        return macos(paths, keep_active, hide_markup)
     elif sys.platform == "win32":
-        return windows(paths, keep_active, delete_comments)
+        return windows(paths, keep_active, hide_markup)
     else:
         raise NotImplementedError(
             "docx2pdf is not implemented for linux as it requires Microsoft Word to be installed"
@@ -177,10 +177,10 @@ def cli():
         help="prevent closing word after conversion",
     )
     parser.add_argument(
-        "--delete-comments",
+        "--hide-markup",
         action="store_true",
         default=False,
-        help="delete all comments from document before conversion",
+        help="hide markup elements (comments, revisions, ink annotations) in PDF output without modifying the original DOCX file",
     )
     parser.add_argument(
         "--version", action="store_true", default=False, help="display version and exit"
@@ -192,4 +192,4 @@ def cli():
     else:
         args = parser.parse_args()
 
-    convert(args.input, args.output, args.keep_active, args.delete_comments)
+    convert(args.input, args.output, args.keep_active, args.hide_markup)

--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 __version__ = version(__package__)
 
 
-def windows(paths, keep_active):
+def windows(paths, keep_active, delete_comments):
     import win32com.client
 
     word = win32com.client.Dispatch("Word.Application")
@@ -24,6 +24,11 @@ def windows(paths, keep_active):
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
             try:
+                if delete_comments:
+                    # Hide comments and revisions in PDF without modifying DOCX
+                    doc.ActiveWindow.View.ShowComments = False
+                    doc.ActiveWindow.View.ShowRevisionsAndComments = False
+                    doc.ActiveWindow.View.RevisionsView = 0  # wdRevisionsViewFinal
                 doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
             except:
                 raise
@@ -35,6 +40,11 @@ def windows(paths, keep_active):
         pdf_filepath = Path(paths["output"]).resolve()
         doc = word.Documents.Open(str(docx_filepath))
         try:
+            if delete_comments:
+                # Hide comments and revisions in PDF without modifying DOCX
+                doc.ActiveWindow.View.ShowComments = False
+                doc.ActiveWindow.View.ShowRevisionsAndComments = False
+                doc.ActiveWindow.View.RevisionsView = 0  # wdRevisionsViewFinal
             doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
         except:
             raise
@@ -46,7 +56,7 @@ def windows(paths, keep_active):
         word.Quit()
 
 
-def macos(paths, keep_active):
+def macos(paths, keep_active, delete_comments):
     script = (Path(__file__).parent / "convert.jxa").resolve()
     cmd = [
         "/usr/bin/osascript",
@@ -56,6 +66,7 @@ def macos(paths, keep_active):
         str(paths["input"]),
         str(paths["output"]),
         str(keep_active).lower(),
+        str(delete_comments).lower(),
     ]
 
     def run(cmd):
@@ -106,12 +117,12 @@ def resolve_paths(input_path, output_path):
     return output
 
 
-def convert(input_path, output_path=None, keep_active=False):
+def convert(input_path, output_path=None, keep_active=False, delete_comments=False):
     paths = resolve_paths(input_path, output_path)
     if sys.platform == "darwin":
-        return macos(paths, keep_active)
+        return macos(paths, keep_active, delete_comments)
     elif sys.platform == "win32":
-        return windows(paths, keep_active)
+        return windows(paths, keep_active, delete_comments)
     else:
         raise NotImplementedError(
             "docx2pdf is not implemented for linux as it requires Microsoft Word to be installed"
@@ -166,6 +177,12 @@ def cli():
         help="prevent closing word after conversion",
     )
     parser.add_argument(
+        "--delete-comments",
+        action="store_true",
+        default=False,
+        help="delete all comments from document before conversion",
+    )
+    parser.add_argument(
         "--version", action="store_true", default=False, help="display version and exit"
     )
 
@@ -175,4 +192,4 @@ def cli():
     else:
         args = parser.parse_args()
 
-    convert(args.input, args.output, args.keep_active)
+    convert(args.input, args.output, args.keep_active, args.delete_comments)

--- a/docx2pdf/convert.jxa
+++ b/docx2pdf/convert.jxa
@@ -58,17 +58,17 @@ function isDir(path) {
   return isDir[0];
 }
 
-function parseArgs([inputPath, outputPath, keepActive, deleteComments, ...rest]) {
+function parseArgs([inputPath, outputPath, keepActive, hideMarkup, ...rest]) {
   const [scriptPath] = getScriptPathAndFolder();
   if (inputPath === undefined || rest.length != 0) {
     console.log(
-      `Error. Usage: ./${scriptPath}.js <INPUT_PATH> <OUTPUT_PATH> <KEEP_ACTIVE> <DELETE_COMMENTS>`
+      `Error. Usage: ./${scriptPath}.js <INPUT_PATH> <OUTPUT_PATH> <KEEP_ACTIVE> <HIDE_MARKUP>`
     );
     $.exit(1);
   }
 
   keepActive = keepActive === "true";
-  deleteComments = deleteComments === "true";
+  hideMarkup = hideMarkup === "true";
 
   inputPath = Path(inputPath).toString();
   if (!outputPath) outputPath = inputPath;
@@ -82,7 +82,7 @@ function parseArgs([inputPath, outputPath, keepActive, deleteComments, ...rest])
       isDir(outputPath),
       `inputPath is a directory, but outputPath either does not exist or is not a directory. outputPath: ${outputPath}`
     );
-    output = { batch: true, inputPath, outputPath, keepActive, deleteComments };
+    output = { batch: true, inputPath, outputPath, keepActive, hideMarkup };
   } else {
     assert(
       inputPath.endsWith(".docx"),
@@ -98,7 +98,7 @@ function parseArgs([inputPath, outputPath, keepActive, deleteComments, ...rest])
       outputPath.endsWith(".pdf"),
       `outputPath does not end with .pdf, outputPath directory may not exist. outputPath: ${outputPath}`
     );
-    output = { batch: false, inputPath, outputPath, keepActive, deleteComments };
+    output = { batch: false, inputPath, outputPath, keepActive, hideMarkup };
   }
 
   return output;
@@ -134,11 +134,11 @@ function run(args) {
       const outputFilePath =
         args.outputPath + "/" + file.replace(".docx", ".pdf");
       try {
-        if (args.deleteComments) {
+        if (args.hideMarkup) {
           // Set view to hide all markup, comments, and revisions in PDF
           // This does NOT modify the original DOCX file
           const view = doc.activeWindow.view;
-          console.log("Setting view to hide comments and revisions...");
+          console.log("Setting view to hide markup elements...");
           view.showComments = false;
           view.showRevisionsAndComments = false;
           view.revisionsView = "revisions view final";
@@ -173,11 +173,11 @@ function run(args) {
     word.open(args.inputPath);
     const doc = word.activeDocument;
     try {
-      if (args.deleteComments) {
+      if (args.hideMarkup) {
         // Set view to hide all markup, comments, and revisions in PDF
         // This does NOT modify the original DOCX file
         const view = doc.activeWindow.view;
-        console.log("Setting view to hide comments and revisions...");
+        console.log("Setting view to hide markup elements...");
         view.showComments = false;
         view.showRevisionsAndComments = false;
         view.revisionsView = "revisions view final";

--- a/docx2pdf/convert.jxa
+++ b/docx2pdf/convert.jxa
@@ -58,16 +58,17 @@ function isDir(path) {
   return isDir[0];
 }
 
-function parseArgs([inputPath, outputPath, keepActive, ...rest]) {
+function parseArgs([inputPath, outputPath, keepActive, deleteComments, ...rest]) {
   const [scriptPath] = getScriptPathAndFolder();
   if (inputPath === undefined || rest.length != 0) {
     console.log(
-      `Error. Usage: ./${scriptPath}.js <INPUT_PATH> <OUTPUT_PATH> <KEEP_ACTIVE>`
+      `Error. Usage: ./${scriptPath}.js <INPUT_PATH> <OUTPUT_PATH> <KEEP_ACTIVE> <DELETE_COMMENTS>`
     );
     $.exit(1);
   }
 
   keepActive = keepActive === "true";
+  deleteComments = deleteComments === "true";
 
   inputPath = Path(inputPath).toString();
   if (!outputPath) outputPath = inputPath;
@@ -81,7 +82,7 @@ function parseArgs([inputPath, outputPath, keepActive, ...rest]) {
       isDir(outputPath),
       `inputPath is a directory, but outputPath either does not exist or is not a directory. outputPath: ${outputPath}`
     );
-    output = { batch: true, inputPath, outputPath, keepActive };
+    output = { batch: true, inputPath, outputPath, keepActive, deleteComments };
   } else {
     assert(
       inputPath.endsWith(".docx"),
@@ -97,7 +98,7 @@ function parseArgs([inputPath, outputPath, keepActive, ...rest]) {
       outputPath.endsWith(".pdf"),
       `outputPath does not end with .pdf, outputPath directory may not exist. outputPath: ${outputPath}`
     );
-    output = { batch: false, inputPath, outputPath, keepActive };
+    output = { batch: false, inputPath, outputPath, keepActive, deleteComments };
   }
 
   return output;
@@ -133,6 +134,16 @@ function run(args) {
       const outputFilePath =
         args.outputPath + "/" + file.replace(".docx", ".pdf");
       try {
+        if (args.deleteComments) {
+          // Set view to hide all markup, comments, and revisions in PDF
+          // This does NOT modify the original DOCX file
+          const view = doc.activeWindow.view;
+          console.log("Setting view to hide comments and revisions...");
+          view.showComments = false;
+          view.showRevisionsAndComments = false;
+          view.revisionsView = "revisions view final";
+          console.log("View settings applied successfully");
+        }
         doc.saveAs({ fileName: outputFilePath, fileFormat: "format PDF" });
         console.log(
           JSON.stringify({
@@ -162,6 +173,16 @@ function run(args) {
     word.open(args.inputPath);
     const doc = word.activeDocument;
     try {
+      if (args.deleteComments) {
+        // Set view to hide all markup, comments, and revisions in PDF
+        // This does NOT modify the original DOCX file
+        const view = doc.activeWindow.view;
+        console.log("Setting view to hide comments and revisions...");
+        view.showComments = false;
+        view.showRevisionsAndComments = false;
+        view.revisionsView = "revisions view final";
+        console.log("View settings applied successfully");
+      }
       doc.saveAs({ fileName: args.outputPath, fileFormat: "format PDF" });
       console.log(
         JSON.stringify({


### PR DESCRIPTION
This pull request introduces a `--hide-markup` parameter to enable hiding markup elements (comments, revisions, ink annotations) when converting DOCX files to PDF. The implementation uses Microsoft Word's view settings to hide markup without modifying the original DOCX file.

API Reference:
Windows (VBA):
- [Document.ActiveWindow.View Property](https://learn.microsoft.com/en-us/office/vba/api/word.window.view)
- [View.ShowComments Property](https://learn.microsoft.com/en-us/office/vba/api/word.view.showcomments)
- [View.ShowRevisionsAndComments Property](https://learn.microsoft.com/en-us/office/vba/api/word.view.showrevisionsandcomments)
- [View.RevisionsView Property](https://learn.microsoft.com/en-us/office/vba/api/word.view.revisionsview)
- [WdRevisionsView Enumeration](https://learn.microsoft.com/en-us/office/vba/api/word.wdrevisionsview) (wdRevisionsViewFinal = 0)